### PR TITLE
使用予定チューナー画面に機能追加

### DIFF
--- a/EpgTimer/EpgTimer/Common/SettingClass.cs
+++ b/EpgTimer/EpgTimer/Common/SettingClass.cs
@@ -245,6 +245,8 @@ namespace EpgTimer
         private bool minHide;
         private bool mouseScrollAuto;
         private int noStyle;
+        private double reserveMinHeight;
+        private bool reservePopup;
 
         public bool UseCustomEpgView
         {
@@ -971,6 +973,16 @@ namespace EpgTimer
             get { return noStyle; }
             set { noStyle = value; }
         }
+        public double ReserveMinHeight
+        {
+            get { return reserveMinHeight; }
+            set { reserveMinHeight = value; }
+        }
+        public bool ReservePopup
+        {
+            get { return reservePopup; }
+            set { reservePopup = value; }
+        }
         
         
         public Settings()
@@ -1103,6 +1115,8 @@ namespace EpgTimer
             minHide = true;
             mouseScrollAuto = false;
             noStyle = 0;
+            reserveMinHeight = 2;
+            reservePopup = false;
         }
 
         [NonSerialized()]

--- a/EpgTimer/EpgTimer/MainWindow.xaml.cs
+++ b/EpgTimer/EpgTimer/MainWindow.xaml.cs
@@ -876,6 +876,7 @@ namespace EpgTimer
                     }
                     epgView.UpdateSetting();
                     cmd.SendReloadSetting();
+                    tunerReserveView.UpdateReserveData();
                     ResetButtonView();
                     ResetTaskMenu();
                 }

--- a/EpgTimer/EpgTimer/Setting/SetEpgView.xaml
+++ b/EpgTimer/EpgTimer/Setting/SetEpgView.xaml
@@ -14,7 +14,12 @@
         <TabControl Name="tabControl">
             <TabItem Header="基本" Name="tabItem_basic">
                 <Grid>
-                    <GroupBox Header="フォント" Margin="6,6,6,0" Name="groupBox3" Height="102" VerticalAlignment="Top">
+                    <Grid.RowDefinitions>
+                        <RowDefinition Height="auto"/>
+                        <RowDefinition Height="auto"/>
+                        <RowDefinition Height="auto"/>
+                    </Grid.RowDefinitions>
+                    <GroupBox Header="フォント" Margin="6,6,6,6" Name="groupBox3" VerticalAlignment="Top" Grid.Row="0">
                         <Grid>
                             <Label Content="タイトル" Height="28" HorizontalAlignment="Left" Margin="6,6,0,0" Name="label1" VerticalAlignment="Top" />
                             <Label Content="フォント" Height="28" HorizontalAlignment="Left" Margin="96,6,0,0" Name="label2" VerticalAlignment="Top" />
@@ -51,7 +56,7 @@
                             <Button Content="" Height="25" HorizontalAlignment="Left" Margin="643,35,0,0" Name="button_colorTitle2" Style="{StaticResource ButtonStyle1}" VerticalAlignment="Top" Width="58" Click="button_colorTitle2_Click" />
                         </Grid>
                     </GroupBox>
-                    <GroupBox Header="表示" Height="213" Margin="6,114,7,0" Name="groupBox2" VerticalAlignment="Top" >
+                    <GroupBox Header="表示" Margin="6,6,6,6" Name="groupBox2" VerticalAlignment="Top" Grid.Row="1">
                         <Grid>
                             <Label Content="マウススクロールサイズ" Height="28" HorizontalAlignment="Left" Margin="11,6,0,0" Name="label7" VerticalAlignment="Top" />
                             <TextBox Height="24" HorizontalAlignment="Left" Margin="165,6,0,0" Name="textBox_mouse_scroll" VerticalAlignment="Top" Width="55" />
@@ -71,6 +76,13 @@
                             <CheckBox Content="自動" Height="16" HorizontalAlignment="Left" Margin="226,11,0,0" Name="checkBox_scrollAuto" VerticalAlignment="Top" />
                             <Label Content="最低表示行数" Height="28" HorizontalAlignment="Left" Margin="551,6,0,0" Name="label36" VerticalAlignment="Top" />
                             <TextBox Height="24" HorizontalAlignment="Left" Margin="650,8,0,0" Name="textBox_minimumHeight" VerticalAlignment="Top" Width="55" />
+                        </Grid>
+                    </GroupBox>
+                    <GroupBox Header="使用予定チューナーの表示設定" Margin="6,6,6,6" Name="groupBox" VerticalAlignment="Top" Grid.Row="2">
+                        <Grid>
+                            <CheckBox Content="番組内容をポップアップ表示する" Height="16" HorizontalAlignment="Left" Margin="11,12,0,0" Name="checkBox_reserve_popup" VerticalAlignment="Top" />
+                            <Label Content="1分あたりの高さ" Height="28" HorizontalAlignment="Left" Margin="327,7,0,0" VerticalAlignment="Top" />
+                            <TextBox Height="24" HorizontalAlignment="Left" Margin="470,9,0,0" Name="textBox_reserve_minHeight" VerticalAlignment="Top" Width="55" />
                         </Grid>
                     </GroupBox>
                 </Grid>

--- a/EpgTimer/EpgTimer/Setting/SetEpgView.xaml.cs
+++ b/EpgTimer/EpgTimer/Setting/SetEpgView.xaml.cs
@@ -176,10 +176,12 @@ namespace EpgTimer.Setting
                 textBox_service_width.Text = Settings.Instance.ServiceWidth.ToString();
                 textBox_dragScroll.Text = Settings.Instance.DragScroll.ToString();
                 textBox_minimumHeight.Text = Settings.Instance.MinimumHeight.ToString();
+                textBox_reserve_minHeight.Text = Settings.Instance.ReserveMinHeight.ToString();
                 checkBox_title_indent.IsChecked = Settings.Instance.EpgTitleIndent;
                 checkBox_epg_popup.IsChecked = Settings.Instance.EpgPopup;
                 checkBox_gradation.IsChecked = Settings.Instance.EpgGradation;
                 checkBox_gradationHeader.IsChecked = Settings.Instance.EpgGradationHeader;
+                checkBox_reserve_popup.IsChecked = Settings.Instance.ReservePopup;
 
                 if (Settings.Instance.UseCustomEpgView == false)
                 {
@@ -291,6 +293,7 @@ namespace EpgTimer.Setting
                 Settings.Instance.ServiceWidth = Convert.ToDouble(textBox_service_width.Text);
                 Settings.Instance.DragScroll = Convert.ToDouble(textBox_dragScroll.Text);
                 Settings.Instance.MinimumHeight = Convert.ToDouble(textBox_minimumHeight.Text);
+                Settings.Instance.ReserveMinHeight = Convert.ToDouble(textBox_reserve_minHeight.Text);
                 if (checkBox_title_indent.IsChecked == true)
                 {
                     Settings.Instance.EpgTitleIndent = true;
@@ -316,6 +319,7 @@ namespace EpgTimer.Setting
                 {
                     Settings.Instance.EpgGradationHeader = false;
                 }
+                Settings.Instance.ReservePopup = (checkBox_reserve_popup.IsChecked == true);
 
                 Settings.Instance.ContentColorList[0x00] = ((ColorSelectionItem)(comboBox0.SelectedItem)).ColorName;
                 Settings.Instance.ContentColorList[0x01] = ((ColorSelectionItem)(comboBox1.SelectedItem)).ColorName;

--- a/EpgTimer/EpgTimer/TunerReserveViewCtrl/TunerReserveMainView.xaml.cs
+++ b/EpgTimer/EpgTimer/TunerReserveViewCtrl/TunerReserveMainView.xaml.cs
@@ -663,10 +663,10 @@ namespace EpgTimer
                         //    duration = (int)Settings.Instance.MinHeight;
                         //}
 
-                        viewItem.Height = Math.Floor((duration / 60) * Settings.Instance.MinHeight);
+                        viewItem.Height = Math.Floor((duration / 60) * Settings.Instance.ReserveMinHeight);
                         if (viewItem.Height == 0)
                         {
-                            viewItem.Height = Settings.Instance.MinHeight;
+                            viewItem.Height = Settings.Instance.ReserveMinHeight;
                         }
                         viewItem.Width = 150;
                         viewItem.LeftPos = leftPos;
@@ -750,7 +750,7 @@ namespace EpgTimer
                     int index = timeList.BinarySearch(chkStartTime);
                     if (index >= 0)
                     {
-                        item.TopPos = (index * 60 + (startTime - chkStartTime).TotalMinutes) * Settings.Instance.MinHeight;
+                        item.TopPos = (index * 60 + (startTime - chkStartTime).TotalMinutes) * Settings.Instance.ReserveMinHeight;
                     }
                 }
 
@@ -758,7 +758,7 @@ namespace EpgTimer
                 tunerReserveNameView.SetTunerInfo(tunerList);
                 tunerReserveView.SetReserveList(reserveList,
                     leftPos,
-                    timeList.Count * 60 * Settings.Instance.MinHeight);
+                    timeList.Count * 60 * Settings.Instance.ReserveMinHeight);
             }
             catch (Exception ex)
             {

--- a/EpgTimer/EpgTimer/TunerReserveViewCtrl/TunerReservePanel.cs
+++ b/EpgTimer/EpgTimer/TunerReserveViewCtrl/TunerReservePanel.cs
@@ -264,7 +264,7 @@ namespace EpgTimer.TunerReserveViewCtrl
                             // ビットマップフォントがかすれる問題
                             totalHeight += useHeight + Math.Floor(sizeNormal / 2);
                         }
-                        widthOffset = 2;
+                        widthOffset = Settings.Instance.EpgTitleIndent ? sizeNormal * 2 : 2;
                         //番組名
                         if (info.ReserveInfo.Title.Length > 0)
                         {

--- a/EpgTimer/EpgTimer/TunerReserveViewCtrl/TunerReservePanel.cs
+++ b/EpgTimer/EpgTimer/TunerReserveViewCtrl/TunerReservePanel.cs
@@ -41,6 +41,13 @@ namespace EpgTimer.TunerReserveViewCtrl
             string[] lineText = text.Replace("\r", "").Split('\n');
             foreach (string line in lineText)
             {
+                //高さ確認
+                if (totalHeight + fontSize > maxHeight)
+                {
+                    //これ以上は無理
+                    useHeight = totalHeight;
+                    return false;
+                }
                 totalHeight += Math.Floor(2 + fontSize);
                 List<ushort> glyphIndexes = new List<ushort>();
                 List<double> advanceWidths = new List<double>();
@@ -97,14 +104,6 @@ namespace EpgTimer.TunerReserveViewCtrl
 
                     dc.DrawGlyphRun(Brushes.Black, glyphRun);
                 }
-                //高さ確認
-                if (totalHeight + fontSize > maxHeight)
-                {
-                    //これ以上は無理
-                    useHeight = totalHeight;
-                    return false;
-                }
-
             }
             useHeight = Math.Floor(totalHeight);
             return true;

--- a/EpgTimer/EpgTimer/TunerReserveViewCtrl/TunerReserveTimeView.xaml.cs
+++ b/EpgTimer/EpgTimer/TunerReserveViewCtrl/TunerReserveTimeView.xaml.cs
@@ -38,7 +38,7 @@ namespace EpgTimer.TunerReserveViewCtrl
                 {
                     TextBlock item = new TextBlock();
 
-                    double height = Settings.Instance.MinHeight;
+                    double height = Settings.Instance.ReserveMinHeight;
                     item.Height = (60 * height) - 4;
 
                     if (time.Hour % 3 == 0 || NeedTimeOnly == true)

--- a/EpgTimer/EpgTimer/TunerReserveViewCtrl/TunerReserveView.xaml
+++ b/EpgTimer/EpgTimer/TunerReserveViewCtrl/TunerReserveView.xaml
@@ -22,8 +22,17 @@
     <Grid>
         <ScrollViewer Name="scrollViewer" HorizontalScrollBarVisibility="Visible" ScrollChanged="scrollViewer_ScrollChanged">
             <Canvas Name="canvas" HorizontalAlignment="Left" VerticalAlignment="Top">
-
-                <local:TunerReservePanel x:Name="reserveViewPanel" Background="DarkGray" MouseMove="reserveViewPanel_MouseMove" MouseLeftButtonDown="reserveViewPanel_MouseLeftButtonDown" MouseLeftButtonUp="reserveViewPanel_MouseLeftButtonUp" HorizontalAlignment="Left" VerticalAlignment="Top" MouseRightButtonDown="reserveViewPanel_MouseRightButtonDown" />
+                <local:TunerReservePanel x:Name="reserveViewPanel" Background="DarkGray" MouseMove="reserveViewPanel_MouseMove" MouseLeftButtonDown="reserveViewPanel_MouseLeftButtonDown" MouseLeftButtonUp="reserveViewPanel_MouseLeftButtonUp" HorizontalAlignment="Left" VerticalAlignment="Top" MouseRightButtonDown="reserveViewPanel_MouseRightButtonDown" MouseLeave="reserveViewPanel_MouseLeave"/>
+                <Border x:Name="popupItem" Background="DarkGray" Visibility="Visible" IsHitTestVisible="False" Canvas.ZIndex="20" BorderBrush="DarkGray" BorderThickness="0.5">
+                    <Border.Effect>
+                        <DropShadowEffect BlurRadius="12" Opacity="0.5"/>
+                    </Border.Effect>
+                    <StackPanel Orientation="Vertical">
+                        <TextBlock x:Name="minText" TextWrapping="Wrap" LineStackingStrategy="BlockLineHeight" VerticalAlignment="Stretch" />
+                        <TextBlock x:Name="titleText" TextWrapping="Wrap" LineStackingStrategy="BlockLineHeight"/>
+                        <TextBlock x:Name="infoText" TextWrapping="Wrap" LineStackingStrategy="BlockLineHeight"/>
+                    </StackPanel>
+                </Border>
             </Canvas>
         </ScrollViewer>
     </Grid>

--- a/EpgTimer/EpgTimer/TunerReserveViewCtrl/TunerReserveView.xaml.cs
+++ b/EpgTimer/EpgTimer/TunerReserveViewCtrl/TunerReserveView.xaml.cs
@@ -41,7 +41,7 @@ namespace EpgTimer.TunerReserveViewCtrl
         private DispatcherTimer toolTipOffTimer;
         private Popup toolTip = new Popup();
         private Point lastPopupPos;
-        private ReserveViewItem lastPopupInfo;
+        private ReserveViewItem lastPopupInfo = null;
 
         public TunerReserveView()
         {
@@ -67,6 +67,8 @@ namespace EpgTimer.TunerReserveViewCtrl
             toolTipTimer.Stop();
             toolTipOffTimer.Stop();
             toolTip.IsOpen = false;
+            lastPopupInfo = null;
+            popupItem.Visibility = System.Windows.Visibility.Hidden;
 
             foreach (Rectangle info in reserveBorder)
             {
@@ -275,7 +277,14 @@ namespace EpgTimer.TunerReserveViewCtrl
 
                             }
 
-                            toolTipTimer.Start();
+                            if (Settings.Instance.ReservePopup)
+                            {
+                                PopupItem();
+                            }
+                            else
+                            {
+                                toolTipTimer.Start();
+                            }
                             lastPopupPos = CursorPos;
                         }
                     }
@@ -358,6 +367,119 @@ namespace EpgTimer.TunerReserveViewCtrl
                     RightClick(sender, cursorPos);
                 }
             }
+        }
+
+        private void reserveViewPanel_MouseLeave(object sender, MouseEventArgs e)
+        {
+            popupItem.Visibility = System.Windows.Visibility.Hidden;
+            lastPopupInfo = null;
+            lastPopupPos = new Point(-1, -1);
+        }
+
+        protected void PopupItem()
+        {
+            ReserveViewItem info = null;
+
+            if (reserveViewPanel.Items != null)
+            {
+                Point cursorPos2 = Mouse.GetPosition(scrollViewer);
+                if (cursorPos2.X < 0 || cursorPos2.Y < 0 ||
+                    scrollViewer.ViewportWidth < cursorPos2.X || scrollViewer.ViewportHeight < cursorPos2.Y)
+                {
+                    return;
+                }
+                Point cursorPos = Mouse.GetPosition(reserveViewPanel);
+                foreach (ReserveViewItem item in reserveViewPanel.Items)
+                {
+                    if (item.LeftPos <= cursorPos.X && cursorPos.X < item.LeftPos + item.Width)
+                    {
+                        if (item.TopPos <= cursorPos.Y && cursorPos.Y < item.TopPos + item.Height)
+                        {
+                            if (item == lastPopupInfo) return;
+
+                            info = item;
+                            lastPopupInfo = info;
+                            lastPopupPos = cursorPos;
+                            break;
+                        }
+                    }
+                }
+            }
+
+            if (info == null || info.ReserveInfo == null)
+            {
+                popupItem.Visibility = System.Windows.Visibility.Hidden;
+                lastPopupInfo = null;
+                return;
+            }
+
+            double sizeNormal = Settings.Instance.FontSize;
+            double sizeTitle = Settings.Instance.FontSizeTitle;
+
+            FontFamily fontNormal = null;
+            FontFamily fontTitle = null;
+            try
+            {
+                if (Settings.Instance.FontName.Length > 0)
+                {
+                    fontNormal = new FontFamily(Settings.Instance.FontName);
+                }
+                if (Settings.Instance.FontNameTitle.Length > 0)
+                {
+                    fontTitle = new FontFamily(Settings.Instance.FontNameTitle);
+                }
+
+                if (fontNormal == null)
+                {
+                    fontNormal = new FontFamily("MS UI Gothic");
+                }
+                if (fontTitle == null)
+                {
+                    fontTitle = new FontFamily("MS UI Gothic");
+                }
+            }
+            catch (Exception ex)
+            {
+                MessageBox.Show(ex.Message + "\r\n" + ex.StackTrace);
+            }
+
+            ReserveItem reserveItem = new ReserveItem(info.ReserveInfo);
+            popupItem.Background = reserveItem.BackColor;
+
+            Canvas.SetTop(popupItem, Math.Floor(info.TopPos));
+            popupItem.MinHeight = Math.Ceiling(info.Height);
+            Canvas.SetLeft(popupItem, Math.Floor(info.LeftPos));
+            popupItem.Width = Math.Ceiling(info.Width);
+
+            String text;
+            DateTime endTime = info.ReserveInfo.StartTime + TimeSpan.FromSeconds(info.ReserveInfo.DurationSecond);
+            text = info.ReserveInfo.StartTime.ToString("HH:mm ～ ");
+            text += endTime.ToString("HH:mm");
+            minText.Text = text;
+            minText.FontFamily = fontNormal;// fontTitle;
+            minText.FontSize = sizeNormal;
+            minText.FontWeight = FontWeights.Normal;
+            minText.Foreground = CommonManager.Instance.CustTitle1Color;
+            minText.Margin = new Thickness(1, 1, 1, 1);
+
+            double indent = Settings.Instance.EpgTitleIndent ? sizeNormal * 2 : 2;
+            text = reserveItem.ServiceName;
+            text += " (" + reserveItem.NetworkName + ")";
+            titleText.Text = text;
+            titleText.FontFamily = fontTitle;
+            titleText.FontSize = sizeTitle;
+            titleText.FontWeight = FontWeights.Bold;
+            titleText.Foreground = CommonManager.Instance.CustTitle1Color;
+            titleText.Margin = new Thickness(indent, 1, 1, sizeNormal / 2);
+
+            infoText.Text = reserveItem.EventName;
+            infoText.FontFamily = fontNormal;
+            infoText.FontSize = sizeNormal;
+            infoText.FontWeight = FontWeights.Normal;
+            infoText.Foreground = CommonManager.Instance.CustTitle2Color;
+            infoText.Margin = new Thickness(indent, 0, 9.5, sizeNormal / 2);
+
+            popupItem.Visibility = System.Windows.Visibility.Visible;
         }
 
     }


### PR DESCRIPTION
ポップアップ表示機能
- デフォルト動作は変更せずツールチップ表示のままとし、見た目は変わらない。
- ポップアップ表示する場合は、設定-基本タブから要変更。

「1分あたりの高さ」を番組表と分離
- デフォルト初期値は番組表初期値と同じ (2)
- 番組表の設定値を変更していた場合、見た目が変わる。そろえる場合は要設定変更。 (デフォルト初期値を番組表の設定値からコピーする処理は使用頻度と煩雑性のバランスにより不採用)
- 自分は 0.8～1.0 位の値を使用して、番組表より圧縮表示している。