### PR TITLE
番組表から右クリックメニューで表示設定を変更しても保存されない問題の修正。

### DIFF
--- a/EpgTimer/EpgTimer/Common/SettingClass.cs
+++ b/EpgTimer/EpgTimer/Common/SettingClass.cs
@@ -247,6 +247,7 @@ namespace EpgTimer
         private int noStyle;
         private double reserveMinHeight;
         private bool reservePopup;
+        private bool alwaysSaveEpgSetting;
 
         public bool UseCustomEpgView
         {
@@ -983,6 +984,11 @@ namespace EpgTimer
             get { return reservePopup; }
             set { reservePopup = value; }
         }
+        public bool AlwaysSaveEpgSetting
+        {
+            get { return alwaysSaveEpgSetting; }
+            set { alwaysSaveEpgSetting = value; }
+        }
         
         
         public Settings()
@@ -1117,6 +1123,7 @@ namespace EpgTimer
             noStyle = 0;
             reserveMinHeight = 2;
             reservePopup = false;
+            alwaysSaveEpgSetting = false;
         }
 
         [NonSerialized()]

--- a/EpgTimer/EpgTimer/DefineClass/CustomEpgTabInfo.cs
+++ b/EpgTimer/EpgTimer/DefineClass/CustomEpgTabInfo.cs
@@ -8,8 +8,11 @@ using CtrlCmdCLI.Def;
 
 namespace EpgTimer
 {
-    public class CustomEpgTabInfo
+    public class CustomEpgTabInfo : IEquatable<CustomEpgTabInfo>
     {
+        private static int count = 0;
+        private int uniqId;
+
         public CustomEpgTabInfo()
         {
             ViewServiceList = new List<UInt64>();
@@ -21,6 +24,7 @@ namespace EpgTimer
             SearchMode = false;
             SearchKey = new EpgSearchKeyInfo();
             FilterEnded = false;
+            uniqId = ++count;
         }
         public String TabName
         {
@@ -98,10 +102,16 @@ namespace EpgTimer
             dest.SearchKey.serviceList = SearchKey.serviceList.ToList();
             dest.SearchKey.titleOnlyFlag = SearchKey.titleOnlyFlag;
             dest.SearchKey.videoList = SearchKey.videoList.ToList();
+
+            dest.uniqId = uniqId;
         }
         public override string ToString()
         {
             return TabName;
+        }
+        public bool Equals(CustomEpgTabInfo other)
+        {
+            return (uniqId == other.uniqId);
         }
     }
 }

--- a/EpgTimer/EpgTimer/EpgDataView.xaml.cs
+++ b/EpgTimer/EpgTimer/EpgDataView.xaml.cs
@@ -332,7 +332,7 @@ namespace EpgTimer
                             {
                                 dlg.Owner = (Window)topWindow.RootVisual;
                             }
-                            dlg.SetDefSetting(setInfo);
+                            dlg.SetDefSetting(setInfo, true);
                             if (dlg.ShowDialog() == true)
                             {
                                 dlg.GetSetting(ref setInfo);

--- a/EpgTimer/EpgTimer/Setting/SetEpgView.xaml.cs
+++ b/EpgTimer/EpgTimer/Setting/SetEpgView.xaml.cs
@@ -486,9 +486,10 @@ namespace EpgTimer.Setting
             {
                 dlg.Owner = (Window)topWindow.RootVisual;
             }
+            CustomEpgTabInfo info = new CustomEpgTabInfo();
+            dlg.SetDefSetting(info, false);
             if (dlg.ShowDialog() == true)
             {
-                CustomEpgTabInfo info = new CustomEpgTabInfo();
                 dlg.GetSetting(ref info);
                 listBox_tab.Items.Add(info);
             }
@@ -505,7 +506,7 @@ namespace EpgTimer.Setting
                     dlg.Owner = (Window)topWindow.RootVisual;
                 }
                 CustomEpgTabInfo setInfo = listBox_tab.SelectedItem as CustomEpgTabInfo;
-                dlg.SetDefSetting(setInfo);
+                dlg.SetDefSetting(setInfo, false);
                 if (dlg.ShowDialog() == true)
                 {
                     dlg.GetSetting(ref setInfo);

--- a/EpgTimer/EpgTimer/UserCtrlView/EpgDataViewSettingWindow.xaml
+++ b/EpgTimer/EpgTimer/UserCtrlView/EpgDataViewSettingWindow.xaml
@@ -14,6 +14,7 @@
         </Grid.RowDefinitions>
         <Button Content="キャンセル" Grid.Row="1" Height="23" HorizontalAlignment="Right" Margin="0,0,12,12" Name="button_cancel" VerticalAlignment="Bottom" Width="75" Click="button_cancel_Click" Style="{StaticResource ButtonStyle1}" />
         <Button Content="OK" Grid.Row="1" Height="23" HorizontalAlignment="Right" Margin="0,0,122,12" Name="button_OK" VerticalAlignment="Bottom" Width="75" Click="button_OK_Click" Style="{StaticResource ButtonStyle1}" />
+        <CheckBox Content="この表示設定と表示条件を保存する" Grid.Row="1" Height="16" HorizontalAlignment="Left" Margin="29,0,0,14" Name="checkBox_save_settings" VerticalAlignment="Bottom" />
         <my:EpgDataViewSetting x:Name="epgDataViewSetting" />
     </Grid>
 </Window>

--- a/EpgTimer/EpgTimer/UserCtrlView/EpgDataViewSettingWindow.xaml.cs
+++ b/EpgTimer/EpgTimer/UserCtrlView/EpgDataViewSettingWindow.xaml.cs
@@ -36,15 +36,26 @@ namespace EpgTimer
                 button_OK.Style = null;
                 button_cancel.Style = null;
             }
+            checkBox_save_settings.IsChecked = false;
         }
 
         /// <summary>
         /// デフォルト表示の設定値
         /// </summary>
         /// <param name="setInfo"></param>
-        public void SetDefSetting(CustomEpgTabInfo setInfo)
+        public void SetDefSetting(CustomEpgTabInfo setInfo, bool show)
         {
             epgDataViewSetting.SetSetting(setInfo);
+
+            if (show)
+            {
+                checkBox_save_settings.Visibility = Visibility.Visible;
+                checkBox_save_settings.IsChecked = (Settings.Instance.AlwaysSaveEpgSetting == true);
+            }
+            else
+            {
+                checkBox_save_settings.Visibility = Visibility.Hidden;
+            }
         }
 
         /// <summary>
@@ -54,6 +65,24 @@ namespace EpgTimer
         public void GetSetting(ref CustomEpgTabInfo info)
         {
             epgDataViewSetting.GetSetting(ref info);
+
+            if (checkBox_save_settings.Visibility == Visibility.Visible)
+            {
+                if (checkBox_save_settings.IsChecked == true)
+                {
+                    int index = Settings.Instance.CustomEpgTabList.IndexOf(info);
+                    if (index >= 0)
+                    {
+                        Settings.Instance.CustomEpgTabList[index] = info;
+                    }
+                    Settings.Instance.AlwaysSaveEpgSetting = true;
+                }
+                else
+                {
+                    Settings.Instance.AlwaysSaveEpgSetting = false;
+                }
+
+            }
         }
 
 


### PR DESCRIPTION
一時的な変更で保存したくない使い方もありそうなので、メニューから変更した場合、保存するかしないかを選択可能なように修正。
デフォルト動作は変更せず、「保存しない」。